### PR TITLE
feat: NesButton apply font color to material icons now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
  - feat: change `NesTab`to use the same border color as `NesContainer`s for design consistency. 
  - feat: allow `NesContainer` to have a customizable `padding`.
  - feat: add `NesDialog`.
+ - feat: `NesButton` font colors applies to material icons.
 
 # 0.7.0
 

--- a/example/lib/app/page/app_page.dart
+++ b/example/lib/app/page/app_page.dart
@@ -49,6 +49,15 @@ class AppPage extends StatelessWidget {
         builder: (context, state) {
           return MaterialApp(
             theme: flutterNesTheme(
+              nesButtonTheme: NesButtonTheme(
+                normal: Colors.white,
+                primary: Colors.blue.shade900,
+                success: Colors.green.shade900,
+                warning: Colors.yellow.shade900,
+                error: Colors.red.shade900,
+                lightLabelColor: Colors.white,
+                darkLabelColor: Colors.black,
+              ),
               brightness: state.lightMode ? Brightness.light : Brightness.dark,
               customExtensions: [
                 CustomExampleExtension.light,

--- a/example/lib/gallery/sections/buttons.dart
+++ b/example/lib/gallery/sections/buttons.dart
@@ -49,6 +49,76 @@ class ButtonsSection extends StatelessWidget {
             const SizedBox(width: 8),
           ],
         ),
+        const SizedBox(height: 32),
+        Text(
+          'With icons',
+          style: theme.textTheme.displayMedium,
+        ),
+        const SizedBox(height: 16),
+        Wrap(
+          children: [
+            NesButton(
+              type: NesButtonType.normal,
+              onPressed: () {},
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  NesIcon(iconData: NesIcons.instance.check),
+                  const SizedBox(width: 8),
+                  const Text('Normal'),
+                ],
+              ),
+            ),
+            const SizedBox(width: 8),
+            NesButton(
+              type: NesButtonType.primary,
+              onPressed: () {},
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  NesIcon(iconData: NesIcons.instance.check),
+                  const SizedBox(width: 8),
+                  const Text('Primary'),
+                ],
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 32),
+        Text(
+          'With material icons',
+          style: theme.textTheme.displayMedium,
+        ),
+        const SizedBox(height: 16),
+        Wrap(
+          children: [
+            NesButton(
+              type: NesButtonType.normal,
+              onPressed: () {},
+              child: const Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(Icons.check),
+                  SizedBox(width: 8),
+                  Text('Normal'),
+                ],
+              ),
+            ),
+            const SizedBox(width: 8),
+            NesButton(
+              type: NesButtonType.primary,
+              onPressed: () {},
+              child: const Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(Icons.check),
+                  SizedBox(width: 8),
+                  Text('Primary'),
+                ],
+              ),
+            ),
+          ],
+        ),
       ],
     );
   }

--- a/lib/src/widgets/nes_button.dart
+++ b/lib/src/widgets/nes_button.dart
@@ -69,13 +69,21 @@ class _NesButtonState extends State<NesButton> {
 
   @override
   Widget build(BuildContext context) {
-    final textStyle =
-        Theme.of(context).textTheme.labelMedium ?? const TextStyle();
+    final materialTheme = Theme.of(context);
+    final textStyle = materialTheme.textTheme.labelMedium ?? const TextStyle();
 
     final nesTheme = context.nesThemeExtension<NesTheme>();
     final nesButtonTheme = context.nesThemeExtension<NesButtonTheme>();
 
     final buttonColor = _mapButtonColor(widget.type, nesButtonTheme);
+
+    final fontColor = buttonColor.isLight()
+        ? nesButtonTheme.darkLabelColor
+        : nesButtonTheme.lightLabelColor;
+
+    final materialIconData = materialTheme.iconTheme.copyWith(
+      color: fontColor,
+    );
 
     return MouseRegion(
       onEnter: (_) {
@@ -104,15 +112,16 @@ class _NesButtonState extends State<NesButton> {
             pressed: widget._isDisabled ? widget._isDisabled : _pressed,
             hovered: widget._isDisabled ? widget._isDisabled : _hovered,
           ),
-          child: DefaultTextStyle(
-            style: textStyle.copyWith(
-              color: buttonColor.isLight()
-                  ? nesButtonTheme.darkLabelColor
-                  : nesButtonTheme.lightLabelColor,
-            ),
-            child: Padding(
-              padding: EdgeInsets.all(nesTheme.pixelSize * 4),
-              child: widget.child,
+          child: Padding(
+            padding: EdgeInsets.all(nesTheme.pixelSize * 4),
+            child: DefaultTextStyle(
+              style: textStyle.copyWith(
+                color: fontColor,
+              ),
+              child: IconTheme(
+                data: materialIconData,
+                child: widget.child,
+              ),
             ),
           ),
         ),


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY**

![Screenshot 2023-09-05 at 21 19 24](https://github.com/erickzanardo/nes_ui/assets/835641/e25d68ec-4df0-4f92-a896-a280ca74f8a3)


## Description

The same color that is applied to `Text`s inside a `NesButton`, is also applied to `Icon`s.

Fixes #70 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
