### PR TITLE
feat!: add button icon themes

### DIFF
--- a/example/lib/app/page/app_page.dart
+++ b/example/lib/app/page/app_page.dart
@@ -57,6 +57,14 @@ class AppPage extends StatelessWidget {
                 error: Colors.red.shade900,
                 lightLabelColor: Colors.white,
                 darkLabelColor: Colors.black,
+                lightIconTheme: const NesIconTheme(
+                  primary: Color(0xff000000),
+                  secondary: Color(0xffffffff),
+                ),
+                darkIconTheme: const NesIconTheme(
+                  primary: Color(0xffffffff),
+                  secondary: Color(0xff000000),
+                ),
               ),
               brightness: state.lightMode ? Brightness.light : Brightness.dark,
               customExtensions: [

--- a/example/lib/app/page/app_page.dart
+++ b/example/lib/app/page/app_page.dart
@@ -58,12 +58,12 @@ class AppPage extends StatelessWidget {
                 lightLabelColor: Colors.white,
                 darkLabelColor: Colors.black,
                 lightIconTheme: const NesIconTheme(
-                  primary: Color(0xff000000),
-                  secondary: Color(0xffffffff),
+                  primary: Colors.white,
+                  secondary: Colors.black,
                 ),
                 darkIconTheme: const NesIconTheme(
-                  primary: Color(0xffffffff),
-                  secondary: Color(0xff000000),
+                  primary: Colors.black,
+                  secondary: Colors.white,
                 ),
               ),
               brightness: state.lightMode ? Brightness.light : Brightness.dark,

--- a/lib/src/theme.dart
+++ b/lib/src/theme.dart
@@ -529,12 +529,12 @@ ThemeData flutterNesTheme({
     lightLabelColor: Color(0xffffffff),
     darkLabelColor: Color(0xff000000),
     lightIconTheme: NesIconTheme(
-      primary: Color(0xff000000),
-      secondary: Color(0xffffffff),
-    ),
-    darkIconTheme: NesIconTheme(
       primary: Color(0xffffffff),
       secondary: Color(0xff000000),
+    ),
+    darkIconTheme: NesIconTheme(
+      primary: Color(0xff000000),
+      secondary: Color(0xffffffff),
     ),
   ),
   NesIconTheme? nesIconTheme,

--- a/lib/src/theme.dart
+++ b/lib/src/theme.dart
@@ -48,6 +48,8 @@ class NesButtonTheme extends ThemeExtension<NesButtonTheme> {
     required this.error,
     required this.lightLabelColor,
     required this.darkLabelColor,
+    required this.lightIconTheme,
+    required this.darkIconTheme,
     this.borderColor,
   });
 
@@ -72,6 +74,12 @@ class NesButtonTheme extends ThemeExtension<NesButtonTheme> {
   /// The color for the labels used on a light colored button.
   final Color darkLabelColor;
 
+  /// The icon theme used on a dark colored button.
+  final NesIconTheme lightIconTheme;
+
+  /// The icon theme used on a light colored button.
+  final NesIconTheme darkIconTheme;
+
   /// The color of the button border. When null, fallbacks
   /// to the [TextTheme.labelMedium] color.
   final Color? borderColor;
@@ -85,6 +93,8 @@ class NesButtonTheme extends ThemeExtension<NesButtonTheme> {
     Color? error,
     Color? lightLabelColor,
     Color? darkLabelColor,
+    NesIconTheme? lightIconTheme,
+    NesIconTheme? darkIconTheme,
     Color? borderColor,
   }) {
     return NesButtonTheme(
@@ -95,6 +105,8 @@ class NesButtonTheme extends ThemeExtension<NesButtonTheme> {
       error: error ?? this.error,
       lightLabelColor: lightLabelColor ?? this.lightLabelColor,
       darkLabelColor: darkLabelColor ?? this.darkLabelColor,
+      lightIconTheme: lightIconTheme ?? this.lightIconTheme,
+      darkIconTheme: darkIconTheme ?? this.darkIconTheme,
       borderColor: borderColor ?? this.borderColor,
     );
   }
@@ -142,6 +154,8 @@ class NesButtonTheme extends ThemeExtension<NesButtonTheme> {
             end: otherExt?.darkLabelColor,
           ).lerp(t) ??
           darkLabelColor,
+      lightIconTheme: lightIconTheme.lerp(otherExt?.lightIconTheme, t),
+      darkIconTheme: darkIconTheme.lerp(otherExt?.darkIconTheme, t),
       borderColor: ColorTween(
             begin: borderColor,
             end: otherExt?.borderColor,
@@ -514,6 +528,14 @@ ThemeData flutterNesTheme({
     error: Color(0xffe76e55),
     lightLabelColor: Color(0xffffffff),
     darkLabelColor: Color(0xff000000),
+    lightIconTheme: NesIconTheme(
+      primary: Color(0xff000000),
+      secondary: Color(0xffffffff),
+    ),
+    darkIconTheme: NesIconTheme(
+      primary: Color(0xffffffff),
+      secondary: Color(0xff000000),
+    ),
   ),
   NesIconTheme? nesIconTheme,
   NesSelectionListTheme nesSelectionListTheme = const NesSelectionListTheme(

--- a/lib/src/widgets/nes_button.dart
+++ b/lib/src/widgets/nes_button.dart
@@ -80,9 +80,12 @@ class _NesButtonState extends State<NesButton> {
     final fontColor = buttonColor.isLight()
         ? nesButtonTheme.darkLabelColor
         : nesButtonTheme.lightLabelColor;
+    final nesIconTheme = buttonColor.isLight()
+        ? nesButtonTheme.darkIconTheme
+        : nesButtonTheme.lightIconTheme;
 
     final materialIconData = materialTheme.iconTheme.copyWith(
-      color: fontColor,
+      color: nesIconTheme.primary,
     );
 
     return MouseRegion(
@@ -118,8 +121,14 @@ class _NesButtonState extends State<NesButton> {
               style: textStyle.copyWith(
                 color: fontColor,
               ),
-              child: IconTheme(
-                data: materialIconData,
+              child: Theme(
+                data: materialTheme.copyWith(
+                  iconTheme: materialIconData,
+                  extensions: [
+                    ...materialTheme.extensions.values,
+                    nesIconTheme,
+                  ],
+                ),
                 child: widget.child,
               ),
             ),


### PR DESCRIPTION
![image](https://github.com/erickzanardo/nes_ui/assets/21128619/e6f223a6-d02a-44f7-9213-85ded265942b)

<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

> **READY/IN DEVELOPMENT/HOLD**

READY

## Description

<!--- Describe your changes in detail -->

Adds button icon themes as discussed in #70.
Resolves #70

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [X] ✨ New feature (non-breaking change which adds functionality)
- [-] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [X] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [-] 🧹 Code refactor
- [-] ✅ Build configuration change
- [-] 📝 Documentation
- [-] 🗑️ Chore
- [-] 🧪 Tests

## Breaking changes

- `NesButtonTheme` now requires two new parameters: `lightIconTheme` and `darkIconTheme`
- Material `Icon`s inside `NesButton`s now follow the `(light/dark)IconTheme`'s primary color instead of the text color