### PR TITLE
refactor: Use `NesIcons.someIcon` instead of `NesIcons.instance.someIcon`

### DIFF
--- a/example/lib/advanced/window_manager/page/window_manager_page.dart
+++ b/example/lib/advanced/window_manager/page/window_manager_page.dart
@@ -49,7 +49,7 @@ class _WindowManagerPageState extends State<WindowManagerPage> {
                         });
                       }
                     },
-                    icon: NesIcons.instance.textFile,
+                    icon: NesIcons.textFile,
                   ),
                   const SizedBox(height: 8),
                   const Text('nes.txt'),
@@ -63,7 +63,7 @@ class _WindowManagerPageState extends State<WindowManagerPage> {
               top: entry.value.y,
               child: NesDropshadow(
                 child: NesWindow(
-                  icon: NesIcons.instance.textFile,
+                  icon: NesIcons.textFile,
                   title: entry.key,
                   width: entry.value.w,
                   height: entry.value.h,

--- a/example/lib/gallery/sections/buttons.dart
+++ b/example/lib/gallery/sections/buttons.dart
@@ -63,7 +63,7 @@ class ButtonsSection extends StatelessWidget {
               child: Row(
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  NesIcon(iconData: NesIcons.instance.check),
+                  NesIcon(iconData: NesIcons.check),
                   const SizedBox(width: 8),
                   const Text('Normal'),
                 ],
@@ -76,7 +76,7 @@ class ButtonsSection extends StatelessWidget {
               child: Row(
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  NesIcon(iconData: NesIcons.instance.check),
+                  NesIcon(iconData: NesIcons.check),
                   const SizedBox(width: 8),
                   const Text('Primary'),
                 ],

--- a/example/lib/gallery/sections/file_explorer.dart
+++ b/example/lib/gallery/sections/file_explorer.dart
@@ -57,7 +57,7 @@ class _FileExplorerSectionState extends State<FileExplorerSection> {
                   left: 0,
                   bottom: 0,
                   child: NesIconButton(
-                    icon: NesIcons.instance.newFile,
+                    icon: NesIcons.newFile,
                     onPress: () {
                       setState(() {
                         _wasAdded = true;

--- a/example/lib/gallery/sections/icon_buttons.dart
+++ b/example/lib/gallery/sections/icon_buttons.dart
@@ -18,31 +18,31 @@ class IconButtonsSection extends StatelessWidget {
         Wrap(
           children: [
             _IconEntry(
-              data: NesIcons.instance.close,
+              data: NesIcons.close,
             ),
             _IconEntry(
-              data: NesIcons.instance.handPointingRight,
+              data: NesIcons.handPointingRight,
             ),
             _IconEntry(
-              data: NesIcons.instance.leftArrowIndicator,
+              data: NesIcons.leftArrowIndicator,
             ),
             _IconEntry(
-              data: NesIcons.instance.rightArrowIndicator,
+              data: NesIcons.rightArrowIndicator,
             ),
             _IconEntry(
-              data: NesIcons.instance.delete,
+              data: NesIcons.delete,
             ),
             _IconEntry(
-              data: NesIcons.instance.add,
+              data: NesIcons.add,
             ),
             _IconEntry(
-              data: NesIcons.instance.remove,
+              data: NesIcons.remove,
             ),
             _IconEntry(
-              data: NesIcons.instance.redo,
+              data: NesIcons.redo,
             ),
             _IconEntry(
-              data: NesIcons.instance.redo,
+              data: NesIcons.redo,
               disabled: true,
             ),
           ],

--- a/example/lib/gallery/sections/icons.dart
+++ b/example/lib/gallery/sections/icons.dart
@@ -18,239 +18,239 @@ class IconsSection extends StatelessWidget {
         Wrap(
           children: [
             _IconEntry(
-              data: NesIcons.instance.check,
+              data: NesIcons.check,
               label: 'check',
             ),
             _IconEntry(
-              data: NesIcons.instance.close,
+              data: NesIcons.close,
               label: 'close',
             ),
             _IconEntry(
-              data: NesIcons.instance.handPointingRight,
+              data: NesIcons.handPointingRight,
               label: 'handPointingRight',
             ),
             _IconEntry(
-              data: NesIcons.instance.leftArrowIndicator,
+              data: NesIcons.leftArrowIndicator,
               label: 'leftArrowIndicator',
             ),
             _IconEntry(
-              data: NesIcons.instance.rightArrowIndicator,
+              data: NesIcons.rightArrowIndicator,
               label: 'rightArrowIndicator',
             ),
             _IconEntry(
-              data: NesIcons.instance.topArrowIndicator,
+              data: NesIcons.topArrowIndicator,
               label: 'topArrowIndicator',
             ),
             _IconEntry(
-              data: NesIcons.instance.bottomArrowIndicator,
+              data: NesIcons.bottomArrowIndicator,
               label: 'bottomArrowIndicator',
             ),
             _IconEntry(
-              data: NesIcons.instance.sword,
+              data: NesIcons.sword,
               label: 'sword',
             ),
             _IconEntry(
-              data: NesIcons.instance.shield,
+              data: NesIcons.shield,
               label: 'shield',
             ),
             _IconEntry(
-              data: NesIcons.instance.axe,
+              data: NesIcons.axe,
               label: 'axe',
             ),
             _IconEntry(
-              data: NesIcons.instance.arrow,
+              data: NesIcons.arrow,
               label: 'arrow',
             ),
             _IconEntry(
-              data: NesIcons.instance.sun,
+              data: NesIcons.sun,
               label: 'sun',
             ),
             _IconEntry(
-              data: NesIcons.instance.moon,
+              data: NesIcons.moon,
               label: 'moon',
             ),
             _IconEntry(
-              data: NesIcons.instance.gallery,
+              data: NesIcons.gallery,
               label: 'gallery',
             ),
             _IconEntry(
-              data: NesIcons.instance.gamepad,
+              data: NesIcons.gamepad,
               label: 'gamepad',
             ),
             _IconEntry(
-              data: NesIcons.instance.delete,
+              data: NesIcons.delete,
               label: 'delete',
             ),
             _IconEntry(
-              data: NesIcons.instance.add,
+              data: NesIcons.add,
               label: 'add',
             ),
             _IconEntry(
-              data: NesIcons.instance.remove,
+              data: NesIcons.remove,
               label: 'remove',
             ),
             _IconEntry(
-              data: NesIcons.instance.redo,
+              data: NesIcons.redo,
               label: 'redo',
             ),
             _IconEntry(
-              data: NesIcons.instance.openFolder,
+              data: NesIcons.openFolder,
               label: 'openFolder',
             ),
             _IconEntry(
-              data: NesIcons.instance.closedFolder,
+              data: NesIcons.closedFolder,
               label: 'closedFolder',
             ),
             _IconEntry(
-              data: NesIcons.instance.thinArrowLeft,
+              data: NesIcons.thinArrowLeft,
               label: 'thinArrowLeft',
             ),
             _IconEntry(
-              data: NesIcons.instance.thinArrowRight,
+              data: NesIcons.thinArrowRight,
               label: 'thinArrowRight',
             ),
             _IconEntry(
-              data: NesIcons.instance.musicNote,
+              data: NesIcons.musicNote,
               label: 'musicNote',
             ),
             _IconEntry(
-              data: NesIcons.instance.keyHole,
+              data: NesIcons.keyHole,
               label: 'keyHole',
             ),
             _IconEntry(
-              data: NesIcons.instance.questionMark,
+              data: NesIcons.questionMark,
               label: 'questionMark',
             ),
             _IconEntry(
-              data: NesIcons.instance.dartLang,
+              data: NesIcons.dartLang,
               label: 'dartLang',
             ),
             _IconEntry(
-              data: NesIcons.instance.bottomConnection,
+              data: NesIcons.bottomConnection,
               label: 'bottomConnection',
             ),
             _IconEntry(
-              data: NesIcons.instance.middleConnection,
+              data: NesIcons.middleConnection,
               label: 'middleConnection',
             ),
             _IconEntry(
-              data: NesIcons.instance.topConnection,
+              data: NesIcons.topConnection,
               label: 'topConnection',
             ),
             _IconEntry(
-              data: NesIcons.instance.threeVerticalDots,
+              data: NesIcons.threeVerticalDots,
               label: 'threeVerticalDots',
             ),
             _IconEntry(
-              data: NesIcons.instance.threeHorizontalDots,
+              data: NesIcons.threeHorizontalDots,
               label: 'threeHorizontalDots',
             ),
             _IconEntry(
-              data: NesIcons.instance.newFile,
+              data: NesIcons.newFile,
               label: 'newFile',
             ),
             _IconEntry(
-              data: NesIcons.instance.saveFile,
+              data: NesIcons.saveFile,
               label: 'saveFile',
             ),
             _IconEntry(
-              data: NesIcons.instance.openEye,
+              data: NesIcons.openEye,
               label: 'openEye',
             ),
             _IconEntry(
-              data: NesIcons.instance.closedEye,
+              data: NesIcons.closedEye,
               label: 'closedEye',
             ),
             _IconEntry(
-              data: NesIcons.instance.window,
+              data: NesIcons.window,
               label: 'window',
             ),
             _IconEntry(
-              data: NesIcons.instance.textFile,
+              data: NesIcons.textFile,
               label: 'textFile',
             ),
             _IconEntry(
-              data: NesIcons.instance.download,
+              data: NesIcons.download,
               label: 'download',
             ),
             _IconEntry(
-              data: NesIcons.instance.zoomIn,
+              data: NesIcons.zoomIn,
               label: 'zoomIn',
             ),
             _IconEntry(
-              data: NesIcons.instance.zoomOut,
+              data: NesIcons.zoomOut,
               label: 'zoomOut',
             ),
             _IconEntry(
-              data: NesIcons.instance.yamlFile,
+              data: NesIcons.yamlFile,
               label: 'yamlFile',
             ),
             _IconEntry(
-              data: NesIcons.instance.xmlFile,
+              data: NesIcons.xmlFile,
               label: 'xmlFile',
             ),
             _IconEntry(
-              data: NesIcons.instance.exclamationMarkBlock,
+              data: NesIcons.exclamationMarkBlock,
               label: 'exclamationMarkBlock',
             ),
             _IconEntry(
-              data: NesIcons.instance.questionMarkBlock,
+              data: NesIcons.questionMarkBlock,
               label: 'questionMarkBlock',
             ),
             _IconEntry(
-              data: NesIcons.instance.leftHand,
+              data: NesIcons.leftHand,
               label: 'leftHand',
             ),
             _IconEntry(
-              data: NesIcons.instance.rightHand,
+              data: NesIcons.rightHand,
               label: 'rightHand',
             ),
             _IconEntry(
-              data: NesIcons.instance.helm,
+              data: NesIcons.helm,
               label: 'helm',
             ),
             _IconEntry(
-              data: NesIcons.instance.upperArmor,
+              data: NesIcons.upperArmor,
               label: 'upperArmor',
             ),
             _IconEntry(
-              data: NesIcons.instance.lowerArmor,
+              data: NesIcons.lowerArmor,
               label: 'lowerArmor',
             ),
             _IconEntry(
-              data: NesIcons.instance.exchange,
+              data: NesIcons.exchange,
               label: 'exchange',
             ),
             _IconEntry(
-              data: NesIcons.instance.edit,
+              data: NesIcons.edit,
               label: 'edit',
             ),
             _IconEntry(
-              data: NesIcons.instance.expand,
+              data: NesIcons.expand,
               label: 'expand',
             ),
             _IconEntry(
-              data: NesIcons.instance.cut,
+              data: NesIcons.cut,
               label: 'cut',
             ),
             _IconEntry(
-              data: NesIcons.instance.eraser,
+              data: NesIcons.eraser,
               label: 'eraser',
             ),
             _IconEntry(
-              data: NesIcons.instance.copy,
+              data: NesIcons.copy,
               label: 'copy',
             ),
             _IconEntry(
-              data: NesIcons.instance.paste,
+              data: NesIcons.paste,
               label: 'paste',
             ),
             _IconEntry(
-              data: NesIcons.instance.tv,
+              data: NesIcons.tv,
               label: 'tv',
             ),
             _IconEntry(
-              data: NesIcons.instance.radio,
+              data: NesIcons.radio,
               label: 'radio',
             ),
           ],

--- a/example/lib/gallery/sections/iterable_options.dart
+++ b/example/lib/gallery/sections/iterable_options.dart
@@ -9,11 +9,11 @@ enum CustomHeroClass {
   NesIconData toIcon() {
     switch (this) {
       case CustomHeroClass.knight:
-        return NesIcons.instance.sword;
+        return NesIcons.sword;
       case CustomHeroClass.archer:
-        return NesIcons.instance.arrow;
+        return NesIcons.arrow;
       case CustomHeroClass.barbarian:
-        return NesIcons.instance.axe;
+        return NesIcons.axe;
     }
   }
 }
@@ -65,10 +65,10 @@ class _IterableOptionsSectionState extends State<IterableOptionsSection> {
               setState(() => customValue = value);
             },
             leftIndicatorBuilder: (_) => NesIcon(
-              iconData: NesIcons.instance.thinArrowLeft,
+              iconData: NesIcons.thinArrowLeft,
             ),
             rightIndicatorBuilder: (_) => NesIcon(
-              iconData: NesIcons.instance.thinArrowRight,
+              iconData: NesIcons.thinArrowRight,
             ),
             optionBuilder: (_, value) => NesIcon(iconData: value.toIcon()),
             value: customValue,

--- a/example/lib/gallery/sections/tooltips.dart
+++ b/example/lib/gallery/sections/tooltips.dart
@@ -22,20 +22,20 @@ class TooltipsSection extends StatelessWidget {
               message: 'This is a tooltip',
               arrowPlacement: NesTooltipArrowPlacement.left,
               child: NesIcon(
-                iconData: NesIcons.instance.exclamationMarkBlock,
+                iconData: NesIcons.exclamationMarkBlock,
               ),
             ),
             NesTooltip(
               message: 'This is a tooltip',
               child: NesIcon(
-                iconData: NesIcons.instance.exclamationMarkBlock,
+                iconData: NesIcons.exclamationMarkBlock,
               ),
             ),
             NesTooltip(
               message: 'This is a tooltip',
               arrowPlacement: NesTooltipArrowPlacement.right,
               child: NesIcon(
-                iconData: NesIcons.instance.exclamationMarkBlock,
+                iconData: NesIcons.exclamationMarkBlock,
               ),
             ),
           ],

--- a/example/lib/gallery/sections/windows.dart
+++ b/example/lib/gallery/sections/windows.dart
@@ -25,12 +25,12 @@ class WindowsSection extends StatelessWidget {
         ),
         const SizedBox(height: 16),
         NesWindow(
-          icon: NesIcons.instance.sword,
+          icon: NesIcons.sword,
           child: const Center(child: Text('With icon')),
         ),
         const SizedBox(height: 16),
         NesWindow(
-          icon: NesIcons.instance.sword,
+          icon: NesIcons.sword,
           title: 'Sword',
           child: const Center(child: Text('With title and icon')),
         ),

--- a/example/lib/widgets/nes_scaffold.dart
+++ b/example/lib/widgets/nes_scaffold.dart
@@ -28,7 +28,7 @@ class NesScaffold extends StatelessWidget {
                 WindowManagerPage.route(),
               );
             },
-            child: NesIcon(iconData: NesIcons.instance.window),
+            child: NesIcon(iconData: NesIcons.window),
           ),
           const SizedBox(height: 16),
           NesButton(
@@ -38,15 +38,15 @@ class NesScaffold extends StatelessWidget {
                 RpgMenuPage.route(),
               );
             },
-            child: NesIcon(iconData: NesIcons.instance.gamepad),
+            child: NesIcon(iconData: NesIcons.gamepad),
           ),
           const SizedBox(height: 16),
           NesButton(
             type: NesButtonType.normal,
             onPressed: cubit.toogleLightMode,
             child: state.lightMode
-                ? NesIcon(iconData: NesIcons.instance.sun)
-                : NesIcon(iconData: NesIcons.instance.moon),
+                ? NesIcon(iconData: NesIcons.sun)
+                : NesIcon(iconData: NesIcons.moon),
           ),
         ],
       ),

--- a/lib/fix_data.yaml
+++ b/lib/fix_data.yaml
@@ -1,6 +1,6 @@
 version: 1
 transforms:
-  - title: 'Use NesIcons instead of NesIcons'
+  - title: 'Use NesIcons instead of NesIcons.instance'
     date: 2023-09-27
     element:
       uris:

--- a/lib/fix_data.yaml
+++ b/lib/fix_data.yaml
@@ -1,0 +1,23 @@
+version: 1
+transforms:
+  - title: 'Use NesIcons instead of NesIcons.instance'
+    date: 2023-09-27
+    element:
+      uris:
+        - 'nes_icon.dart'
+        - 'src/widgets/nes_icon.dart'
+        - 'package:nes_ui/src/widgets/nes_icon.dart'
+        - 'nes_ui.dart'
+        - 'package:nes_ui/nes_ui.dart'
+      variable: 'instance'
+      inClass: 'NesIconCollection'
+    changes:
+      - kind: 'replacedBy'
+        newElement:
+          uris:
+            - 'nes_icon.dart'
+            - 'src/widgets/nes_icon.dart'
+            - 'package:nes_ui/src/widgets/nes_icon.dart'
+            - 'nes_ui.dart'
+            - 'package:nes_ui/nes_ui.dart'
+          variable: 'NesIcons'

--- a/lib/fix_data.yaml
+++ b/lib/fix_data.yaml
@@ -1,6 +1,6 @@
 version: 1
 transforms:
-  - title: 'Use NesIcons instead of NesIcons.instance'
+  - title: 'Use NesIcons instead of NesIcons'
     date: 2023-09-27
     element:
       uris:

--- a/lib/src/widgets/dialogs/nes_dialog.dart
+++ b/lib/src/widgets/dialogs/nes_dialog.dart
@@ -63,7 +63,7 @@ class NesDialog extends StatelessWidget {
                     },
                     child: NesIcon(
                       size: const Size(16, 16),
-                      iconData: NesIcons.instance.close,
+                      iconData: NesIcons.close,
                     ),
                   ),
                 ),

--- a/lib/src/widgets/nes_check_box.dart
+++ b/lib/src/widgets/nes_check_box.dart
@@ -42,7 +42,7 @@ class NesCheckBox extends StatelessWidget {
         child: value
             ? Transform.translate(
                 offset: const Offset(2, -6),
-                child: NesIcon(iconData: NesIcons.instance.check),
+                child: NesIcon(iconData: NesIcons.check),
               )
             : null,
       ),

--- a/lib/src/widgets/nes_file_explorer.dart
+++ b/lib/src/widgets/nes_file_explorer.dart
@@ -171,39 +171,39 @@ class _Entry extends StatelessWidget {
 
     switch (file.name) {
       case 'LICENSE':
-        return NesIcons.instance.keyHole;
+        return NesIcons.keyHole;
     }
 
     switch (extension) {
       case 'mp3':
       case 'wav':
       case 'ogg':
-        return NesIcons.instance.musicNote;
+        return NesIcons.musicNote;
       case 'png':
       case 'jpg':
       case 'jpeg':
-        return NesIcons.instance.gallery;
+        return NesIcons.gallery;
       case 'dart':
-        return NesIcons.instance.dartLang;
+        return NesIcons.dartLang;
       case 'txt':
-        return NesIcons.instance.textFile;
+        return NesIcons.textFile;
       case 'yml':
       case 'yaml':
-        return NesIcons.instance.yamlFile;
+        return NesIcons.yamlFile;
       case 'xml':
-        return NesIcons.instance.xmlFile;
+        return NesIcons.xmlFile;
       default:
-        return NesIcons.instance.questionMark;
+        return NesIcons.questionMark;
     }
   }
 
   NesIconData _getConnectionIcon(int i, int length) {
     if (i == 0 && length == 1) {
-      return NesIcons.instance.bottomConnection;
+      return NesIcons.bottomConnection;
     } else if (i == length - 1) {
-      return NesIcons.instance.bottomConnection;
+      return NesIcons.bottomConnection;
     } else {
-      return NesIcons.instance.middleConnection;
+      return NesIcons.middleConnection;
     }
   }
 
@@ -244,8 +244,8 @@ class _Entry extends StatelessWidget {
                 children: [
                   NesIcon(
                     iconData: isOpen
-                        ? NesIcons.instance.openFolder
-                        : NesIcons.instance.closedFolder,
+                        ? NesIcons.openFolder
+                        : NesIcons.closedFolder,
                   ),
                   const SizedBox(width: 8),
                   Text(entry.name),

--- a/lib/src/widgets/nes_file_explorer.dart
+++ b/lib/src/widgets/nes_file_explorer.dart
@@ -243,9 +243,8 @@ class _Entry extends StatelessWidget {
               child: Row(
                 children: [
                   NesIcon(
-                    iconData: isOpen
-                        ? NesIcons.openFolder
-                        : NesIcons.closedFolder,
+                    iconData:
+                        isOpen ? NesIcons.openFolder : NesIcons.closedFolder,
                   ),
                   const SizedBox(width: 8),
                   Text(entry.name),

--- a/lib/src/widgets/nes_icon.dart
+++ b/lib/src/widgets/nes_icon.dart
@@ -18,11 +18,17 @@ class NesIconData {
 }
 
 /// Built in library of icons for the Flutter Nes Design library.
-class NesIcons {
-  NesIcons._();
+// ignore: non_constant_identifier_names
+final NesIcons = NesIconCollection._singleton();
 
-  /// Instance of [NesIcons].
-  static final NesIcons instance = NesIcons._();
+/// This is the internal class that holds the data for [NesIcons].
+/// Use [NesIcons] to access the icons.
+class NesIconCollection {
+  NesIconCollection._singleton();
+
+  /// Instance of [NesIconCollection].
+  @Deprecated('Instance is no longer needed. Use NesIcons directly.')
+  late final NesIconCollection instance = NesIcons;
 
   /// A check icon.
   late final check = NesIconData(

--- a/lib/src/widgets/nes_iterable_options.dart
+++ b/lib/src/widgets/nes_iterable_options.dart
@@ -63,7 +63,7 @@ class NesIterableOptions<T> extends StatelessWidget {
       children: [
         NesPressable(
           child: leftIndicatorBuilder?.call(context) ??
-              NesIcon(iconData: NesIcons.instance.leftArrowIndicator),
+              NesIcon(iconData: NesIcons.leftArrowIndicator),
           onPress: () {
             _select(-1);
           },
@@ -71,7 +71,7 @@ class NesIterableOptions<T> extends StatelessWidget {
         optionBuilder?.call(context, value) ?? Text(value.toString()),
         NesPressable(
           child: rightIndicatorBuilder?.call(context) ??
-              NesIcon(iconData: NesIcons.instance.rightArrowIndicator),
+              NesIcon(iconData: NesIcons.rightArrowIndicator),
           onPress: () {
             _select(1);
           },

--- a/lib/src/widgets/nes_iterable_options.dart
+++ b/lib/src/widgets/nes_iterable_options.dart
@@ -8,9 +8,9 @@ import 'package:nes_ui/nes_ui.dart';
 /// inside a [Text] widget. That can be customized by informing a
 /// [optionBuilder].
 ///
-/// The default selection controllers are [NesIcons.leftArrowIndicator] and
-/// [NesIcons.rightArrowIndicator], that can be also be customized by passing
-/// a [leftIndicatorBuilder] and [rightIndicatorBuilder].
+/// The default selection controllers are [NesIconCollection.leftArrowIndicator]
+/// and [NesIconCollection.rightArrowIndicator], that can be also be customized
+/// by passing a [leftIndicatorBuilder] and [rightIndicatorBuilder].
 /// {@endtemplate}
 class NesIterableOptions<T> extends StatelessWidget {
   /// {@template nes_iterable_options}

--- a/lib/src/widgets/nes_key_icon.dart
+++ b/lib/src/widgets/nes_key_icon.dart
@@ -33,9 +33,8 @@ class NesKeyIcon extends StatelessWidget {
 
     final pixelSize = nesTheme.pixelSize.toDouble();
 
-    final iconData = pressed
-        ? NesIcons.pressedButton
-        : NesIcons.unpressedButton;
+    final iconData =
+        pressed ? NesIcons.pressedButton : NesIcons.unpressedButton;
 
     final buttonSize = size ??
         Size(

--- a/lib/src/widgets/nes_key_icon.dart
+++ b/lib/src/widgets/nes_key_icon.dart
@@ -34,8 +34,8 @@ class NesKeyIcon extends StatelessWidget {
     final pixelSize = nesTheme.pixelSize.toDouble();
 
     final iconData = pressed
-        ? NesIcons.instance.pressedButton
-        : NesIcons.instance.unpressedButton;
+        ? NesIcons.pressedButton
+        : NesIcons.unpressedButton;
 
     final buttonSize = size ??
         Size(

--- a/lib/src/widgets/nes_scrollbar.dart
+++ b/lib/src/widgets/nes_scrollbar.dart
@@ -150,8 +150,8 @@ class _NesScrollbarState extends State<NesScrollbar> {
                 child: NesIconButton(
                   size: const Size(16, 16),
                   icon: widget.direction == Axis.vertical
-                      ? NesIcons.instance.topArrowIndicator
-                      : NesIcons.instance.leftArrowIndicator,
+                      ? NesIcons.topArrowIndicator
+                      : NesIcons.leftArrowIndicator,
                   onPressStart: () {
                     _startScrolling(false);
                   },
@@ -190,8 +190,8 @@ class _NesScrollbarState extends State<NesScrollbar> {
                 child: NesIconButton(
                   size: const Size(16, 16),
                   icon: widget.direction == Axis.vertical
-                      ? NesIcons.instance.bottomArrowIndicator
-                      : NesIcons.instance.rightArrowIndicator,
+                      ? NesIcons.bottomArrowIndicator
+                      : NesIcons.rightArrowIndicator,
                   onPressStart: () {
                     _startScrolling(true);
                   },

--- a/lib/src/widgets/nes_selection_list.dart
+++ b/lib/src/widgets/nes_selection_list.dart
@@ -25,7 +25,7 @@ class NesSelectionList extends StatefulWidget {
 
   /// A [WidgetBuilder] used to create the marker widget.
   ///
-  /// If ommited [NesIcons.instances.handPointingRight] is used.
+  /// If ommited [NesIconCollection.handPointingRight] is used.
   final Widget Function(BuildContext, Size)? markerBuilder;
 
   /// List of items tha can be selected.
@@ -158,7 +158,7 @@ class _NesSelectionListState extends State<NesSelectionList> {
   Widget build(BuildContext context) {
     final markerBuilder = widget.markerBuilder ??
         (_, size) => NesIcon(
-              iconData: NesIcons.instance.handPointingRight,
+              iconData: NesIcons.handPointingRight,
               size: size,
             );
 

--- a/lib/src/widgets/nes_split_panel.dart
+++ b/lib/src/widgets/nes_split_panel.dart
@@ -181,8 +181,8 @@ class NesSplitPanelResizeHandler extends StatelessWidget {
             child: NesIcon(
               size: const Size.square(16),
               iconData: orientation == Axis.horizontal
-                  ? NesIcons.instance.threeVerticalDots
-                  : NesIcons.instance.threeHorizontalDots,
+                  ? NesIcons.threeVerticalDots
+                  : NesIcons.threeHorizontalDots,
             ),
           ),
         ),

--- a/lib/src/widgets/nes_tab.dart
+++ b/lib/src/widgets/nes_tab.dart
@@ -53,7 +53,7 @@ class NesTab extends StatelessWidget {
                   padding: const EdgeInsets.only(right: 16),
                   child: NesIconButton(
                     size: const Size.square(24),
-                    icon: NesIcons.instance.close,
+                    icon: NesIcons.close,
                     onPress: onClosed,
                   ),
                 ),

--- a/lib/src/widgets/nes_window.dart
+++ b/lib/src/widgets/nes_window.dart
@@ -100,7 +100,7 @@ class NesWindow extends StatelessWidget {
               ),
             if (onClose != null)
               NesIconButton(
-                icon: NesIcons.instance.close,
+                icon: NesIcons.close,
                 size: iconSize,
                 onPress: onClose,
               ),

--- a/test/src/widgets/nes_check_box_test.dart
+++ b/test/src/widgets/nes_check_box_test.dart
@@ -37,7 +37,7 @@ void main() {
 
       final icon = tester.widget<NesIcon>(find.byType(NesIcon));
 
-      expect(icon.iconData, equals(NesIcons.instance.check));
+      expect(icon.iconData, equals(NesIcons.check));
     });
   });
 }

--- a/test/src/widgets/nes_icon_button_test.dart
+++ b/test/src/widgets/nes_icon_button_test.dart
@@ -11,7 +11,7 @@ void main() {
           home: Scaffold(
             body: NesIconButton(
               onPress: () {},
-              icon: NesIcons.instance.add,
+              icon: NesIcons.add,
             ),
           ),
         ),
@@ -29,7 +29,7 @@ void main() {
           home: Scaffold(
             body: NesIconButton(
               onPress: () => calls++,
-              icon: NesIcons.instance.add,
+              icon: NesIcons.add,
             ),
           ),
         ),

--- a/test/src/widgets/nes_icon_test.dart
+++ b/test/src/widgets/nes_icon_test.dart
@@ -10,7 +10,7 @@ void main() {
           theme: flutterNesTheme(),
           home: Scaffold(
             body: NesIcon(
-              iconData: NesIcons.instance.check,
+              iconData: NesIcons.check,
             ),
           ),
         ),

--- a/test/src/widgets/nes_window_test.dart
+++ b/test/src/widgets/nes_window_test.dart
@@ -38,7 +38,7 @@ void main() {
           theme: flutterNesTheme(),
           home: Scaffold(
             body: NesWindow(
-              icon: NesIcons.instance.sword,
+              icon: NesIcons.sword,
             ),
           ),
         ),
@@ -146,7 +146,7 @@ void main() {
             theme: flutterNesTheme(),
             home: Scaffold(
               body: NesWindow(
-                icon: NesIcons.instance.sword,
+                icon: NesIcons.sword,
                 onMove: (_) {},
                 onResize: (_) {},
               ),

--- a/test_fixes/README.md
+++ b/test_fixes/README.md
@@ -1,0 +1,17 @@
+## nes_ui test_fixes
+
+The Dart files and their corresponding `.expect` files are used to
+test this package's refactorings used with the `dart fix` command.
+
+To test these fixes locally, run:
+```bash
+cd test_fixes
+dart fix --compare-to-golden
+```
+
+See
+[lib/fix_data.yaml](https://github.com/erickzanardo/nes_ui/blob/main/lib/fix_data.yaml)
+for the current data-driven fixes.
+
+For more documentation about Data Driven Fixes, see
+https://dart.dev/go/data-driven-fixes.

--- a/test_fixes/analysis_options.yaml
+++ b/test_fixes/analysis_options.yaml
@@ -1,0 +1,1 @@
+# This ensures that parent analysis options do not accidentally break the fix tests.

--- a/test_fixes/nes_icons_instance.dart
+++ b/test_fixes/nes_icons_instance.dart
@@ -1,0 +1,3 @@
+import 'package:nes_ui/nes_ui.dart';
+
+final icon = NesIcons.instance.add;

--- a/test_fixes/nes_icons_instance.dart
+++ b/test_fixes/nes_icons_instance.dart
@@ -1,3 +1,3 @@
 import 'package:nes_ui/nes_ui.dart';
 
-final icon = NesIcons.add;
+final icon = NesIcons.instance.add;

--- a/test_fixes/nes_icons_instance.dart
+++ b/test_fixes/nes_icons_instance.dart
@@ -1,3 +1,3 @@
 import 'package:nes_ui/nes_ui.dart';
 
-final icon = NesIcons.instance.add;
+final icon = NesIcons.add;

--- a/test_fixes/nes_icons_instance.dart.expect
+++ b/test_fixes/nes_icons_instance.dart.expect
@@ -1,0 +1,3 @@
+import 'package:nes_ui/nes_ui.dart';
+
+final icon = NesIcons.add;


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY/IN DEVELOPMENT/HOLD**

READY

## Description

<!--- Describe your changes in detail -->

This PR removes the need for `NesIcons.instance.someIcon` so we can just use `NesIcons.someIcon`.
Fixes https://github.com/erickzanardo/nes_ui/issues/8

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [X] ✨ New feature (non-breaking change which adds functionality)
- [-] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [-] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [X] 🧹 Code refactor
- [-] ✅ Build configuration change
- [-] 📝 Documentation
- [-] 🗑️ Chore
- [-] 🧪 Tests

## Breaking change?

`NesIcons.instance` now has a deprecation warning. Users can simply replace `NesIcons.instance` with `NesIcons` to remove this warning, but the code will work identically even if they don't.

### Why didn't you make `NesIcons` static/abstract?

There's no way to support `NesIcons.instance` for backwards compatibility if I made `NesIcons` static. Therefore, I opted to use a singleton pattern with a (deprecated) `instance` field to avoid breaking changes.

(Please ignore the branch name)

### Can `dart fix` automatically change `NesIcons.instance` to `NesIcons`?

Not currently.
Although `kind: 'replacedBy'` is mentioned in the [documentation](https://dart.dev/go/data-driven-fixes), it's not currently doing anything in my testing.

I'm guessing that we just need to wait for a newer Flutter version (and its corresponding newer Dart) for `dart fix` to work. For now though, devs will just need to change `NesIcons.instance` to `NesIcons` manually (e.g. through a find-and-replace).