### PR TITLE
fix: icon button disabled property

### DIFF
--- a/example/lib/gallery/sections/icon_buttons.dart
+++ b/example/lib/gallery/sections/icon_buttons.dart
@@ -65,7 +65,7 @@ class _IconEntry extends StatelessWidget {
   Widget build(BuildContext context) {
     return Padding(
       padding: const EdgeInsets.all(8),
-      child: NesIconButton(icon: data, onPress: disabled ? null : () {}),
+      child: NesIconButton(icon: data, onPress: () {}, disabled: disabled, ),
     );
   }
 }

--- a/example/lib/gallery/sections/tooltips.dart
+++ b/example/lib/gallery/sections/tooltips.dart
@@ -19,21 +19,50 @@ class TooltipsSection extends StatelessWidget {
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [
             NesTooltip(
-              message: 'This is a tooltip',
+              message: 'This is a top tooltip',
               arrowPlacement: NesTooltipArrowPlacement.left,
               child: NesIcon(
                 iconData: NesIcons.exclamationMarkBlock,
               ),
             ),
             NesTooltip(
-              message: 'This is a tooltip',
+              message: 'This is a top tooltip',
               child: NesIcon(
                 iconData: NesIcons.exclamationMarkBlock,
               ),
             ),
             NesTooltip(
-              message: 'This is a tooltip',
+              message: 'This is a top tooltip',
               arrowPlacement: NesTooltipArrowPlacement.right,
+              child: NesIcon(
+                iconData: NesIcons.exclamationMarkBlock,
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 16),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            NesTooltip(
+              message: 'This is a bottom tooltip',
+              arrowPlacement: NesTooltipArrowPlacement.left,
+              arrowDirection: NesTooltipArrowDirection.bottom,
+              child: NesIcon(
+                iconData: NesIcons.exclamationMarkBlock,
+              ),
+            ),
+            NesTooltip(
+              message: 'This is a bottom tooltip',
+              arrowDirection: NesTooltipArrowDirection.bottom,
+              child: NesIcon(
+                iconData: NesIcons.exclamationMarkBlock,
+              ),
+            ),
+            NesTooltip(
+              message: 'This is a bottom tooltip',
+              arrowPlacement: NesTooltipArrowPlacement.right,
+              arrowDirection: NesTooltipArrowDirection.bottom,
               child: NesIcon(
                 iconData: NesIcons.exclamationMarkBlock,
               ),

--- a/lib/src/widgets/nes_icon_button.dart
+++ b/lib/src/widgets/nes_icon_button.dart
@@ -15,6 +15,7 @@ class NesIconButton extends StatelessWidget {
     this.size,
     this.primaryColor,
     this.secondaryColor,
+    this.disabled,
   });
 
   /// Icon of the button.
@@ -40,6 +41,9 @@ class NesIconButton extends StatelessWidget {
   /// An optional size for the icon button.
   final Size? size;
 
+  /// Disable the button
+  final bool? disabled;
+
   bool _isDisabled() =>
       onPress == null && onPressStart == null && onPressEnd == null;
 
@@ -49,8 +53,9 @@ class NesIconButton extends StatelessWidget {
       onPress: onPress,
       onPressStart: onPressStart,
       onPressEnd: onPressEnd,
+      disabled: disabled ?? false || _isDisabled(),
       child: Opacity(
-        opacity: _isDisabled() ? .2 : 1.0,
+        opacity: (disabled ?? false || _isDisabled()) ? .2 : 1.0,
         child: NesIcon(
           iconData: icon,
           size: size,

--- a/lib/src/widgets/nes_pressabled.dart
+++ b/lib/src/widgets/nes_pressabled.dart
@@ -12,6 +12,7 @@ class NesPressable extends StatefulWidget {
     this.onPressStart,
     this.onPressEnd,
     this.onPress,
+    this.disabled,
     super.key,
   });
 
@@ -23,6 +24,9 @@ class NesPressable extends StatefulWidget {
 
   /// Called when the press input has happened.
   final VoidCallback? onPress;
+
+  /// Disabled pressable component
+  final bool? disabled;
 
   /// Child.
   final Widget child;
@@ -37,8 +41,12 @@ class _NesPressableState extends State<NesPressable> {
   @override
   Widget build(BuildContext context) {
     final nesTheme = context.nesThemeExtension<NesTheme>();
+    final offSet = Offset(
+      0,
+      (_pressed && widget.disabled != true) ? nesTheme.pixelSize.toDouble() : 0,
+    );
     return Transform.translate(
-      offset: Offset(0, _pressed ? nesTheme.pixelSize.toDouble() : 0),
+      offset: offSet,
       child: MouseRegion(
         cursor: SystemMouseCursors.click,
         child: GestureDetector(

--- a/lib/src/widgets/nes_tooltip.dart
+++ b/lib/src/widgets/nes_tooltip.dart
@@ -14,8 +14,12 @@ enum NesTooltipArrowPlacement {
   right,
 }
 
+/// Enum with the possible direction for the arrow of the tooltip.
 enum NesTooltipArrowDirection {
+  /// The arrow will be direct on the top side of the tooltip. (Default value)
   top,
+
+  /// The arrow will be direct on the bottom side of the tooltip.
   bottom,
 }
 

--- a/lib/src/widgets/nes_tooltip.dart
+++ b/lib/src/widgets/nes_tooltip.dart
@@ -46,7 +46,7 @@ class NesTooltip extends StatefulWidget {
   /// The placement of the arrow of the tooltip.
   final NesTooltipArrowPlacement arrowPlacement;
 
-  /// The direction fo the arrow of the tooltip
+  /// The direction for the arrow of the tooltip
   final NesTooltipArrowDirection arrowDirection;
 
   @override

--- a/lib/src/widgets/nes_tooltip.dart
+++ b/lib/src/widgets/nes_tooltip.dart
@@ -14,6 +14,11 @@ enum NesTooltipArrowPlacement {
   right,
 }
 
+enum NesTooltipArrowDirection {
+  top,
+  bottom,
+}
+
 /// {@template nes_tooltip}
 /// A tooltip that appears when the user long-presses on a widget,
 /// or hovers over it with a mouse.
@@ -25,6 +30,7 @@ class NesTooltip extends StatefulWidget {
     required this.child,
     required this.message,
     this.arrowPlacement = NesTooltipArrowPlacement.middle,
+    this.arrowDirection = NesTooltipArrowDirection.top,
   });
 
   /// The Widget that will trigger the tooltip.
@@ -35,6 +41,9 @@ class NesTooltip extends StatefulWidget {
 
   /// The placement of the arrow of the tooltip.
   final NesTooltipArrowPlacement arrowPlacement;
+
+  /// The direction fo the arrow of the tooltip
+  final NesTooltipArrowDirection arrowDirection;
 
   @override
   State<NesTooltip> createState() => _NesTooltipState();
@@ -56,6 +65,7 @@ class _NesTooltipState extends State<NesTooltip> {
               color: tooltipTheme.background,
               pixelSize: nesTheme.pixelSize.toDouble(),
               arrowPlacement: widget.arrowPlacement,
+              arrowDirection: widget.arrowDirection,
               textStyle: textStyle,
               message: widget.message,
               textColor: tooltipTheme.textColor,
@@ -100,6 +110,7 @@ class _TooltipPainter extends CustomPainter {
     required this.color,
     required this.pixelSize,
     required this.arrowPlacement,
+    required this.arrowDirection,
     required this.textStyle,
     required this.textColor,
     required this.message,
@@ -108,6 +119,7 @@ class _TooltipPainter extends CustomPainter {
   final Color color;
   final double pixelSize;
   final NesTooltipArrowPlacement arrowPlacement;
+  final NesTooltipArrowDirection arrowDirection;
   final TextStyle textStyle;
   final Color textColor;
   final String message;
@@ -160,7 +172,10 @@ class _TooltipPainter extends CustomPainter {
       NesTooltipArrowPlacement.right => -size.width + childSize.width,
     };
 
-    final translateY = -size.height - pixelSize * 4;
+    final translateY = switch (arrowDirection) {
+      NesTooltipArrowDirection.top => -size.height - pixelSize * 4,
+      NesTooltipArrowDirection.bottom => size.height + pixelSize * 8,
+    };
 
     canvas
       ..translate(translateX, translateY)
@@ -189,12 +204,21 @@ class _TooltipPainter extends CustomPainter {
 
     textPainter.paint(canvas, Offset(pixelSize * 2, pixelSize));
 
+    final arrowBodyTopPosition = switch (arrowDirection) {
+      NesTooltipArrowDirection.top => size.height + pixelSize,
+      NesTooltipArrowDirection.bottom => pixelSize * -2,
+    };
+
+    final arrowHeadTopPosition = switch (arrowDirection) {
+      NesTooltipArrowDirection.top => size.height + pixelSize * 2,
+      NesTooltipArrowDirection.bottom => pixelSize * -3,
+    };
     // Arrow
     canvas
       ..drawRect(
         Rect.fromLTWH(
           arrowOffset,
-          size.height + pixelSize,
+          arrowBodyTopPosition,
           pixelSize * 2,
           pixelSize,
         ),
@@ -203,7 +227,7 @@ class _TooltipPainter extends CustomPainter {
       ..drawRect(
         Rect.fromLTWH(
           arrowOffset + pixelSize / 2,
-          size.height + pixelSize * 2,
+          arrowHeadTopPosition,
           pixelSize,
           pixelSize,
         ),


### PR DESCRIPTION
Note: I opened wrong pr and I'm sorry for this. I created this pr above this pr: https://github.com/erickzanardo/nes_ui/pull/104 because of this these 2 pr connected. But If #104 accepted this pr will fix.

## Status

**READY**

## Description

When icon button disabled (previous version onPressed is null but now there is a disabled param) Nespressable do not change offset. Because button is disabled but still can be clicked and animations are still working but this version if icon button is disabled there is no animation

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
