### PR TITLE
feat: allow changing transition duration

### DIFF
--- a/lib/src/screen_transitions/nes_fill.dart
+++ b/lib/src/screen_transitions/nes_fill.dart
@@ -15,11 +15,12 @@ class NesFillTransition extends NesOverlayTransitionWidget {
   /// Creates a route with this animation.
   static PageRouteBuilder<T> route<T>({
     required RoutePageBuilder pageBuilder,
+    Duration duration = const Duration(milliseconds: 750),
   }) {
     return PageRouteBuilder<T>(
       pageBuilder: pageBuilder,
-      reverseTransitionDuration: const Duration(milliseconds: 750),
-      transitionDuration: const Duration(milliseconds: 750),
+      reverseTransitionDuration: duration,
+      transitionDuration: duration,
       transitionsBuilder: (context, animation, secondaryAnimation, child) {
         return NesFillTransition(
           animation: animation,

--- a/lib/src/screen_transitions/nes_horizontal_close.dart
+++ b/lib/src/screen_transitions/nes_horizontal_close.dart
@@ -16,11 +16,12 @@ class NesHorizontalCloseTransition extends NesOverlayTransitionWidget {
   /// Creates a route with this animation.
   static PageRouteBuilder<T> route<T>({
     required RoutePageBuilder pageBuilder,
+    Duration duration = const Duration(milliseconds: 750),
   }) {
     return PageRouteBuilder<T>(
       pageBuilder: pageBuilder,
-      reverseTransitionDuration: const Duration(milliseconds: 750),
-      transitionDuration: const Duration(milliseconds: 750),
+      reverseTransitionDuration: duration,
+      transitionDuration: duration,
       transitionsBuilder: (context, animation, secondaryAnimation, child) {
         return NesHorizontalCloseTransition(
           animation: animation,

--- a/lib/src/screen_transitions/nes_horizontal_grid.dart
+++ b/lib/src/screen_transitions/nes_horizontal_grid.dart
@@ -16,11 +16,12 @@ class NesHorizontalGridTransition extends NesOverlayTransitionWidget {
   /// Creates a route with this animation.
   static PageRouteBuilder<T> route<T>({
     required RoutePageBuilder pageBuilder,
+    Duration duration = const Duration(milliseconds: 1750),
   }) {
     return PageRouteBuilder<T>(
       pageBuilder: pageBuilder,
-      reverseTransitionDuration: const Duration(milliseconds: 1750),
-      transitionDuration: const Duration(milliseconds: 1750),
+      reverseTransitionDuration: duration,
+      transitionDuration: duration,
       transitionsBuilder: (context, animation, secondaryAnimation, child) {
         return NesHorizontalGridTransition(
           animation: animation,

--- a/lib/src/screen_transitions/nes_vertical_close.dart
+++ b/lib/src/screen_transitions/nes_vertical_close.dart
@@ -16,11 +16,12 @@ class NesVerticalCloseTransition extends NesOverlayTransitionWidget {
   /// Creates a route with this animation.
   static PageRouteBuilder<T> route<T>({
     required RoutePageBuilder pageBuilder,
+    Duration duration = const Duration(milliseconds: 750),
   }) {
     return PageRouteBuilder<T>(
       pageBuilder: pageBuilder,
-      reverseTransitionDuration: const Duration(milliseconds: 750),
-      transitionDuration: const Duration(milliseconds: 750),
+      reverseTransitionDuration: duration,
+      transitionDuration: duration,
       transitionsBuilder: (context, animation, secondaryAnimation, child) {
         return NesVerticalCloseTransition(
           animation: animation,

--- a/lib/src/screen_transitions/nes_vertical_grid.dart
+++ b/lib/src/screen_transitions/nes_vertical_grid.dart
@@ -16,11 +16,12 @@ class NesVerticalGridTransition extends NesOverlayTransitionWidget {
   /// Creates a route with this animation.
   static PageRouteBuilder<T> route<T>({
     required RoutePageBuilder pageBuilder,
+    Duration duration = const Duration(milliseconds: 1750),
   }) {
     return PageRouteBuilder<T>(
       pageBuilder: pageBuilder,
-      reverseTransitionDuration: const Duration(milliseconds: 1750),
-      transitionDuration: const Duration(milliseconds: 1750),
+      reverseTransitionDuration: duration,
+      transitionDuration: duration,
       transitionsBuilder: (context, animation, secondaryAnimation, child) {
         return NesVerticalGridTransition(
           animation: animation,


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

Allows developers to specify the transition duration like so:
```dart
Navigator.of(context).push(
  NesVerticalCloseTransition.route<void>(
    pageBuilder: widget.openBuilder,
    duration: const Duration(milliseconds: 300),
  ),
);
```

## Status

Ready for review

## Description

Adds an optional argument to `NesVerticalCloseTransition.route` (and likewise with the other transition classes) to specify the transition duration, see https://github.com/adil192/ricochlime/issues/41.

My first thought was to add a field to `NesOverlayTransitionTheme` but since the durations are different for each transition (i.e. 750ms vs 1750ms), it would be less verbose to just add a parameter to the `....route<T>()` functions.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [X] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
