### PR TITLE
feat: Update nes_tooltip to use foreground painter

### DIFF
--- a/lib/src/widgets/nes_tooltip.dart
+++ b/lib/src/widgets/nes_tooltip.dart
@@ -64,7 +64,7 @@ class _NesTooltipState extends State<NesTooltip> {
     final nesTheme = context.nesThemeExtension<NesTheme>();
 
     return CustomPaint(
-      painter: _show
+      foregroundPainter: _show
           ? _TooltipPainter(
               color: tooltipTheme.background,
               pixelSize: nesTheme.pixelSize.toDouble(),


### PR DESCRIPTION
## Status

**READY**

## Description

Change CustomPaint painter to foregroundPainter. This paints the Tooltip after the child instead of before.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [X] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
- [ ] 🧪 Tests
