### PR TITLE
feat: Add textTheme parameter to flutterNesTheme()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # 0.29.0
+ - feat: Add `textTheme` parameter to `flutterNesTheme()` to allow custom text themes.
 
 # 0.28.0
  - feat: Add an optional `decoration` parameter to `NesContainer`

--- a/lib/src/theme.dart
+++ b/lib/src/theme.dart
@@ -851,7 +851,7 @@ extension NesBuildContext on BuildContext {
 /// Creates a Flutter Nes [ThemeData].
 ///
 /// Use [textTheme] to override the default Press Start 2P font
-/// for non-Latin locales.
+/// for non-Latin locales or just to use a different, custom `TextTheme`.
 ThemeData flutterNesTheme({
   Color primaryColor = const Color(0xffb4b6f6),
   Brightness brightness = Brightness.light,


### PR DESCRIPTION
Closes #246

Adds an optional `TextTheme? textTheme` parameter to `flutterNesTheme()`.

When provided, it replaces the default Press Start 2P text theme, enabling non-Latin locales to use custom pixel fonts while ensuring all internal theme derivations use the correct font.

### Changes
- Added `TextTheme? textTheme` parameter to `flutterNesTheme()`
- Internal variable renamed to `resolvedTextTheme` to avoid shadowing
- No breaking changes — default behavior preserved when parameter is omitted