### PR TITLE
feat: add NesShakeEffect widget with shaking bool and optional controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # 0.30.0
+ - feat: Add `NesShakeEffect` widget with declarative `shaking` bool and optional `NesShakeEffectController`.
  - feat: Add `NesContainerMultiStepCornerPainter` with configurable `cornerSteps` for multi-step pixel-rounded corners.
  - feat: Add `mainAxisSize` parameter to `NesSelectionList`.
  - feat: Add `NesIcons.tnt`.

--- a/example/lib/gallery/sections/effects.dart
+++ b/example/lib/gallery/sections/effects.dart
@@ -1,8 +1,21 @@
 import 'package:flutter/material.dart';
 import 'package:nes_ui/nes_ui.dart';
 
-class EffectsSection extends StatelessWidget {
+class EffectsSection extends StatefulWidget {
   const EffectsSection({super.key});
+
+  @override
+  State<EffectsSection> createState() => _EffectsSectionState();
+}
+
+class _EffectsSectionState extends State<EffectsSection> {
+  final _shakeController = NesShakeEffectController();
+
+  @override
+  void dispose() {
+    _shakeController.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -23,6 +36,15 @@ class EffectsSection extends StatelessWidget {
             SizedBox(
               height: 40,
               child: NesPulser(child: const Text('NES Pulser')),
+            ),
+            const SizedBox(width: 16),
+            NesShakeEffect(
+              controller: _shakeController,
+              child: NesButton(
+                type: NesButtonType.normal,
+                onPressed: _shakeController.shake,
+                child: const Text('Shake!'),
+              ),
             ),
           ],
         ),

--- a/lib/src/widgets/nes_shake_effect.dart
+++ b/lib/src/widgets/nes_shake_effect.dart
@@ -1,0 +1,202 @@
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+
+/// A controller for [NesShakeEffect].
+///
+/// Call [shake] to trigger the shake animation programmatically.
+class NesShakeEffectController extends ChangeNotifier {
+  bool _shouldShake = false;
+
+  /// Whether the shake effect is currently requested.
+  bool get shouldShake => _shouldShake;
+
+  /// Triggers a single shake animation.
+  void shake() {
+    _shouldShake = true;
+    notifyListeners();
+  }
+
+  /// Resets the shake state. Called internally when the animation completes.
+  void reset() {
+    _shouldShake = false;
+  }
+}
+
+/// {@template nes_shake_effect}
+/// A widget that shakes its child.
+///
+/// The shake can be controlled either declaratively via the [shaking]
+/// parameter, or imperatively via a [NesShakeEffectController].
+///
+/// When [shaking] is true, the widget will continuously shake until
+/// it is set back to false.
+///
+/// When using a controller, call [NesShakeEffectController.shake] to
+/// trigger a single shake that auto-stops after [duration].
+/// {@endtemplate}
+class NesShakeEffect extends StatefulWidget {
+  /// {@macro nes_shake_effect}
+  const NesShakeEffect({
+    super.key,
+    this.shaking = false,
+    this.controller,
+    this.intensity = 4.0,
+    this.duration = const Duration(milliseconds: 300),
+    required this.child,
+  });
+
+  /// Whether the widget is currently shaking.
+  ///
+  /// When set to true, the widget will shake continuously until
+  /// this is set back to false.
+  final bool shaking;
+
+  /// An optional controller to trigger shakes programmatically.
+  ///
+  /// If not provided, one will be created internally.
+  final NesShakeEffectController? controller;
+
+  /// The maximum pixel offset of the shake.
+  final double intensity;
+
+  /// The duration of a single shake animation.
+  final Duration duration;
+
+  /// The child widget to shake.
+  final Widget child;
+
+  @override
+  State<NesShakeEffect> createState() => NesShakeEffectState();
+}
+
+/// State for [NesShakeEffect].
+class NesShakeEffectState extends State<NesShakeEffect>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _animationController;
+  final Random _random = Random();
+
+  NesShakeEffectController? _internalController;
+
+  /// The effective controller, either the one provided by the user or
+  /// one created internally.
+  NesShakeEffectController get _effectiveController =>
+      widget.controller ?? (_internalController ??= NesShakeEffectController());
+
+  double _offsetX = 0;
+  double _offsetY = 0;
+
+  @override
+  void initState() {
+    super.initState();
+
+    _animationController = AnimationController(
+      vsync: this,
+      duration: widget.duration,
+    )
+      ..addListener(_onAnimationTick)
+      ..addStatusListener(_onAnimationStatus);
+
+    _effectiveController.addListener(_onControllerUpdate);
+
+    if (widget.shaking) {
+      _startShake();
+    }
+  }
+
+  @override
+  void didUpdateWidget(NesShakeEffect oldWidget) {
+    super.didUpdateWidget(oldWidget);
+
+    if (widget.duration != oldWidget.duration) {
+      _animationController.duration = widget.duration;
+    }
+
+    if (widget.controller != oldWidget.controller) {
+      oldWidget.controller?.removeListener(_onControllerUpdate);
+
+      if (oldWidget.controller == null && widget.controller != null) {
+        _internalController?.removeListener(_onControllerUpdate);
+        _internalController?.dispose();
+        _internalController = null;
+      }
+
+      _effectiveController.addListener(_onControllerUpdate);
+    }
+
+    if (widget.shaking != oldWidget.shaking) {
+      if (widget.shaking) {
+        _startShake();
+      } else {
+        _stopShake();
+      }
+    }
+  }
+
+  @override
+  void dispose() {
+    _animationController
+      ..removeListener(_onAnimationTick)
+      ..removeStatusListener(_onAnimationStatus)
+      ..dispose();
+
+    _effectiveController.removeListener(_onControllerUpdate);
+    _internalController?.dispose();
+
+    super.dispose();
+  }
+
+  void _onControllerUpdate() {
+    if (_effectiveController.shouldShake) {
+      _startShake();
+    }
+  }
+
+  void _onAnimationTick() {
+    final decay = 1.0 - _animationController.value;
+
+    setState(() {
+      _offsetX = (_random.nextDouble() * 2 - 1) * widget.intensity * decay;
+      _offsetY = (_random.nextDouble() * 2 - 1) * widget.intensity * decay;
+    });
+  }
+
+  void _onAnimationStatus(AnimationStatus status) {
+    if (status == AnimationStatus.completed) {
+      _effectiveController.reset();
+
+      if (widget.shaking) {
+        _animationController
+          ..reset()
+          ..forward();
+      } else {
+        setState(() {
+          _offsetX = 0;
+          _offsetY = 0;
+        });
+      }
+    }
+  }
+
+  void _startShake() {
+    _animationController
+      ..reset()
+      ..forward();
+  }
+
+  void _stopShake() {
+    _animationController.stop();
+    setState(() {
+      _offsetX = 0;
+      _offsetY = 0;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Transform.translate(
+      offset: Offset(_offsetX, _offsetY),
+      child: widget.child,
+    );
+  }
+}

--- a/lib/src/widgets/widgets.dart
+++ b/lib/src/widgets/widgets.dart
@@ -29,6 +29,7 @@ export 'nes_scaffold.dart';
 export 'nes_scrollbar.dart';
 export 'nes_section_header.dart';
 export 'nes_selection_list.dart';
+export 'nes_shake_effect.dart';
 export 'nes_single_child_scroll_view.dart';
 export 'nes_snackbar.dart';
 export 'nes_split_panel.dart';

--- a/widgetbook/lib/widgetbook/use_cases/shake_effect.dart
+++ b/widgetbook/lib/widgetbook/use_cases/shake_effect.dart
@@ -1,0 +1,140 @@
+// ignore_for_file: public_member_api_docs
+
+import 'package:flutter/material.dart';
+import 'package:nes_ui/nes_ui.dart';
+import 'package:widgetbook_annotation/widgetbook_annotation.dart' as widgetbook;
+
+@widgetbook.UseCase(name: 'default (declarative)', type: NesShakeEffect)
+Widget defaultShake(BuildContext context) => const Center(
+      child: _DeclarativeShakeDemo(),
+    );
+
+@widgetbook.UseCase(name: 'with controller', type: NesShakeEffect)
+Widget withController(BuildContext context) => const Center(
+      child: _ControllerShakeDemo(),
+    );
+
+@widgetbook.UseCase(name: 'with custom intensity', type: NesShakeEffect)
+Widget customIntensity(BuildContext context) => const Center(
+      child: _CustomIntensityDemo(),
+    );
+
+class _DeclarativeShakeDemo extends StatefulWidget {
+  const _DeclarativeShakeDemo();
+
+  @override
+  State<_DeclarativeShakeDemo> createState() => _DeclarativeShakeDemoState();
+}
+
+class _DeclarativeShakeDemoState extends State<_DeclarativeShakeDemo> {
+  bool _shaking = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        NesShakeEffect(
+          shaking: _shaking,
+          child: const NesContainer(
+            width: 200,
+            height: 100,
+            child: Center(child: Text('Shake me!')),
+          ),
+        ),
+        const SizedBox(height: 16),
+        NesButton(
+          type: NesButtonType.normal,
+          onPressed: () {
+            setState(() {
+              _shaking = !_shaking;
+            });
+          },
+          child: Text(_shaking ? 'Stop' : 'Start'),
+        ),
+      ],
+    );
+  }
+}
+
+class _ControllerShakeDemo extends StatefulWidget {
+  const _ControllerShakeDemo();
+
+  @override
+  State<_ControllerShakeDemo> createState() => _ControllerShakeDemoState();
+}
+
+class _ControllerShakeDemoState extends State<_ControllerShakeDemo> {
+  final _controller = NesShakeEffectController();
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        NesShakeEffect(
+          controller: _controller,
+          child: const NesContainer(
+            width: 200,
+            height: 100,
+            child: Center(child: Text('Shake me!')),
+          ),
+        ),
+        const SizedBox(height: 16),
+        NesButton(
+          type: NesButtonType.normal,
+          onPressed: _controller.shake,
+          child: const Text('Shake!'),
+        ),
+      ],
+    );
+  }
+}
+
+class _CustomIntensityDemo extends StatefulWidget {
+  const _CustomIntensityDemo();
+
+  @override
+  State<_CustomIntensityDemo> createState() => _CustomIntensityDemoState();
+}
+
+class _CustomIntensityDemoState extends State<_CustomIntensityDemo> {
+  final _controller = NesShakeEffectController();
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        NesShakeEffect(
+          controller: _controller,
+          intensity: 8,
+          duration: const Duration(milliseconds: 500),
+          child: const NesContainer(
+            width: 200,
+            height: 100,
+            child: Center(child: Text('Heavy shake!')),
+          ),
+        ),
+        const SizedBox(height: 16),
+        NesButton(
+          type: NesButtonType.normal,
+          onPressed: _controller.shake,
+          child: const Text('Shake!'),
+        ),
+      ],
+    );
+  }
+}

--- a/widgetbook/lib/widgetbook/widgetbook.directories.g.dart
+++ b/widgetbook/lib/widgetbook/widgetbook.directories.g.dart
@@ -73,6 +73,8 @@ import 'package:widgetbook_app/widgetbook/use_cases/section_header.dart'
     as _widgetbook_app_widgetbook_use_cases_section_header;
 import 'package:widgetbook_app/widgetbook/use_cases/selection_list.dart'
     as _widgetbook_app_widgetbook_use_cases_selection_list;
+import 'package:widgetbook_app/widgetbook/use_cases/shake_effect.dart'
+    as _widgetbook_app_widgetbook_use_cases_shake_effect;
 import 'package:widgetbook_app/widgetbook/use_cases/single_child_scroll_view.dart'
     as _widgetbook_app_widgetbook_use_cases_single_child_scroll_view;
 import 'package:widgetbook_app/widgetbook/use_cases/snackbar.dart'
@@ -528,6 +530,26 @@ final directories = <_widgetbook.WidgetbookNode>[
             name: 'with disabled items',
             builder: _widgetbook_app_widgetbook_use_cases_selection_list
                 .withDisabledItems,
+          ),
+        ],
+      ),
+      _widgetbook.WidgetbookComponent(
+        name: 'NesShakeEffect',
+        useCases: [
+          _widgetbook.WidgetbookUseCase(
+            name: 'default (declarative)',
+            builder:
+                _widgetbook_app_widgetbook_use_cases_shake_effect.defaultShake,
+          ),
+          _widgetbook.WidgetbookUseCase(
+            name: 'with controller',
+            builder: _widgetbook_app_widgetbook_use_cases_shake_effect
+                .withController,
+          ),
+          _widgetbook.WidgetbookUseCase(
+            name: 'with custom intensity',
+            builder: _widgetbook_app_widgetbook_use_cases_shake_effect
+                .customIntensity,
           ),
         ],
       ),


### PR DESCRIPTION
## Description

Adds a `NesShakeEffect` widget that shakes its child widget, useful for game juice effects like damage feedback, explosions, or error indicators.

Closes #254

## API

Supports both **declarative** and **imperative** usage:

### Declarative (shaking bool)

```dart
NesShakeEffect(
  shaking: isDamaged,  // true = shaking, false = stopped
  child: healthBar,
)
```

### Imperative (controller)

```dart
final controller = NesShakeEffectController();

NesShakeEffect(
  controller: controller,
  intensity: 8,
  duration: Duration(milliseconds: 500),
  child: NesContainer(child: Text('HP: 42')),
)

// trigger a single shake
controller.shake();
```

If no controller is passed, one is created internally using Flutter's `effectiveController` pattern (`ScrollController` / `TextEditingController` style).

## Changes

- **New file**: `lib/src/widgets/nes_shake_effect.dart` (`NesShakeEffectController` + `NesShakeEffect`)
- **Export**: Added to `widgets.dart`
- **Example gallery**: Added shake button to Effects section
- **Widgetbook**: 3 use cases (declarative, controller, custom intensity)
- **CHANGELOG**: Added entry under 0.30.0